### PR TITLE
Utility: Improve `Util_CharDeleteAtIndex` performance

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 
-extern char* Util_CharDeleteAtIndex(char* src, int index);
+extern void Util_CharDeleteAtIndex(char* src, int index);
 extern char* Util_BuildStringFromChunk(char* str, int start, int end);
 
 #endif // _UTIL_H_

--- a/source/html/html_parser.c
+++ b/source/html/html_parser.c
@@ -223,7 +223,7 @@ char* HTML_CleanDocument(char* html_data)
             // While everything after the new line is a space
             // or a tab, re-build the document data without it.
             while(html_data[i] == ' ' || html_data[i] == '\t') {
-                html_data = Util_CharDeleteAtIndex(html_data, i);
+                Util_CharDeleteAtIndex(html_data, i);
             }
         } 
         // We found a standard space (' ')
@@ -235,7 +235,7 @@ char* HTML_CleanDocument(char* html_data)
             while(multiple_spaces) {
                 // Is this slot a space, too?
                 if (html_data[i] == ' ') {
-                    html_data = Util_CharDeleteAtIndex(html_data, i);
+                    Util_CharDeleteAtIndex(html_data, i);
                 } 
                 // It wasn't, stop trying to scrub.
                 else {

--- a/source/util.c
+++ b/source/util.c
@@ -22,29 +22,20 @@
 
 #define MAX_TEMP_STR_LEN    512
 
-char* tempstr = NULL;
-
-char* Util_CharDeleteAtIndex(char* src, int index)
+void Util_CharDeleteAtIndex(char* src, int index)
 {
     int len = strlen(src);
 
-    if (tempstr != NULL) {
-        free(tempstr);
-        tempstr = NULL;
+    if (index < 0 || index >= len) {
+        // Invalid index, do nothing
+        return;
     }
 
-    tempstr = malloc(sizeof(char) * (len + 1));
-
-    int j = 0;
-    for(int i = 0; i < len; i++) {
-        if (i != index) {
-            tempstr[j] = src[i];
-            j++;
-        }
+    int i;
+    for (i = index; i < len - 1; i++) {
+        src[i] = src[i + 1];
     }
-    tempstr[j] = '\0';
-
-    return tempstr;
+    src[i] = '\0';
 }
 
 char* Util_BuildStringFromChunk(char* str, int start, int end)


### PR DESCRIPTION
Before, this utility function would allocate a new string and iterate through it entirely to fill every entry aside from the index we wanted to ignore. Now, it simply jumps to the index at hand, and just replaces it and subsequence indexes with the character in front of it. This mitigates the need to continually allocate and free memory, instead relying on the same string build and modifying it. Fixes #6.